### PR TITLE
Update Hexo 8 guides and add new post tutorial

### DIFF
--- a/source/_posts/hexo-deploy-customization.md
+++ b/source/_posts/hexo-deploy-customization.md
@@ -28,10 +28,12 @@ hexo server --draft
 hexo deploy
 ```
 
-這會依照 `deploy` 區塊設定，將 `public/` 內容推送到指定平台。若要先檢查輸出後再部署，可使用：
+這會依照 `deploy` 區塊設定，將 `public/` 內容推送到指定平台。若要先檢查輸出後再部署，請先執行 `hexo generate`、確認 `public/` 或以 `hexo server` 預覽，完成檢查後再用以下指令發布：
 
 ```bash
-hexo generate --deploy
+hexo deploy
+# 或確認無誤後一次生成並部署
+hexo generate && hexo deploy
 ```
 
 在 Hexo 8 中仍可搭配 git、rsync 或自訂腳本部署；若使用 GitHub Actions，亦可使用官方推薦的 Node.js 18 以上執行環境。

--- a/source/_posts/hexo-deploy-customization.md
+++ b/source/_posts/hexo-deploy-customization.md
@@ -1,0 +1,67 @@
+---
+title: Hexo 8 部署與客製化技巧
+date: 2025-11-26 11:00:00
+tags: [Hexo, deploy, customization]
+---
+
+完成文章後，接下來就是發布與持續優化。以下整理 Hexo 8 常用的部署流程與客製化建議，搭配指令示例。
+
+<!-- more -->
+
+## 產生與預覽輸出
+
+部署前建議先重新產生靜態檔並做預覽：
+
+```bash
+hexo clean
+hexo generate
+hexo server --draft
+```
+
+`--draft` 會包含草稿頁面，方便檢查尚未發布的內容。
+
+## 一鍵部署到遠端
+
+若已在 `_config.yml` 設定部署目標（如 GitHub Pages 或 S3），即可直接發布：
+
+```bash
+hexo deploy
+```
+
+這會依照 `deploy` 區塊設定，將 `public/` 內容推送到指定平台。若要先檢查輸出後再部署，可使用：
+
+```bash
+hexo generate --deploy
+```
+
+在 Hexo 8 中仍可搭配 git、rsync 或自訂腳本部署；若使用 GitHub Actions，亦可使用官方推薦的 Node.js 18 以上執行環境。
+
+## 常見的部署檢查點
+
+- 確認 `_config.yml` 的 `url` 與 `root` 設定正確，避免產生錯誤連結。
+- 部署前執行 `hexo clean` 避免舊檔案殘留。
+- 使用外掛（如 `hexo-algolia`、`hexo-minify`）時，建議鎖定與 Hexo 8 相容的版本並重新安裝。
+
+## 佈景主題與樣式客製化
+
+調整佈景主題的設定檔（例如 `themes/modern-dark/_config.yml`）即可改變導覽列、首頁英雄標題或社群連結：
+
+```bash
+# 修改標題或副標題後重新生成
+hexo generate
+```
+
+若需要新增自訂樣式，通常可在佈景主題的 `source/css` 或 `source/_data` 中建立覆寫檔，再重新生成站點。
+
+## 自動化部署與備份
+
+可以結合 CI/CD 平台（GitHub Actions、GitLab CI 等）實現自動化發佈：
+
+```bash
+# 以 GitHub Actions 為例，工作流程步驟可能包含
+npm ci
+hexo generate
+hexo deploy
+```
+
+此外，也建議將 `source/`、`themes/` 與 `_config.yml` 等設定推送到版本控制，確保客製化與文章內容都有備份。

--- a/source/_posts/hexo-new-post-guide.md
+++ b/source/_posts/hexo-new-post-guide.md
@@ -1,0 +1,83 @@
+---
+title: Hexo 8 新增文章與草稿流程
+date: 2025-11-26 12:00:00
+tags: [Hexo, writing, markdown]
+---
+
+在 Hexo 8 中建立新文章十分簡單，以下整理新增文章、草稿與常用 Front Matter 的寫法，並附上指令範例。
+
+<!-- more -->
+
+## 建立正式文章
+
+在專案根目錄執行 `hexo new`，會依照 `scaffolds/post.md` 產生檔案並填入標題與日期：
+
+```bash
+hexo new "我的第一篇文章"
+```
+
+預設會放在 `source/_posts/`，並包含 `title`、`date`、`tags` 等欄位，可直接以 Markdown 撰寫內容。
+
+## 建立草稿再發布
+
+尚未完成的文章可先建立草稿，避免出現在正式列表：
+
+```bash
+hexo new draft "尚未完成的文章"
+```
+
+草稿會放在 `source/_drafts/`。檢視草稿可啟動含草稿的開發伺服器：
+
+```bash
+hexo server --draft
+```
+
+完成後使用 `publish` 轉成正式文章：
+
+```bash
+hexo publish "尚未完成的文章"
+```
+
+## 常用 Front Matter 欄位
+
+在文章開頭可調整以下欄位，幫助 SEO 與分類：
+
+```yaml
+title: 我的第一篇文章
+date: 2025-11-26 12:34:00
+tags: [Hexo, 教學]
+categories: [技術, 部落格]
+summary: 一段自訂的摘要，會顯示在列表或社群分享卡片。
+```
+
+- `tags`：用於標籤頁面聚合，可寫多個。
+- `categories`：多層分類會自動生成巢狀路徑。
+- `summary`：部分主題會以此欄位覆蓋自動摘要。
+
+## 圖片與資產管理
+
+若希望每篇文章有獨立的資產資料夾，可啟用 `post_asset_folder: true`（於 `_config.yml`）。啟用後：
+
+```bash
+hexo new "帶圖片的文章"
+# 將圖片放到 source/_posts/帶圖片的文章/
+```
+
+Markdown 內可相對引用：
+
+```markdown
+![封面](帶圖片的文章/cover.png)
+```
+
+## 發布前的檢查
+
+撰寫完成後，建議按以下順序檢查並發布：
+
+```bash
+hexo clean
+hexo generate
+hexo server --draft   # 最後一次預覽含草稿的狀態
+hexo deploy           # 部署到遠端
+```
+
+搭配 Hexo 8 的最新版 CLI，可確保寫作與部署流程與官方相容。

--- a/source/_posts/hexo-setup-workflow.md
+++ b/source/_posts/hexo-setup-workflow.md
@@ -1,0 +1,82 @@
+---
+title: Hexo 8 安裝與本機開發流程
+date: 2025-11-26 10:00:00
+tags: [Hexo, setup, Node.js]
+---
+
+想快速搭建 Hexo 8 部落格？以下整理從安裝到本機開發的必要步驟，並提供常用指令範例。
+
+<!-- more -->
+
+## 環境準備（Node.js 18+）
+
+Hexo 8 官方建議 Node.js 18+。可用下列指令確認版本：
+
+```bash
+node -v
+npm -v
+```
+
+若尚未安裝，請至官方網站下載或使用套件管理工具安裝。
+
+## 安裝 Hexo CLI（最新版）
+
+以 npm 全域安裝並鎖定最新 Hexo CLI：
+
+```bash
+npm install -g hexo-cli@latest
+```
+
+安裝完成後檢查版本，確認 Hexo 核心與 CLI 均為 8.x：
+
+```bash
+hexo -v
+```
+
+## 初始化專案與安裝相依
+
+在目標資料夾執行初始化，Hexo 會產生必要目錄結構與 `package.json`：
+
+```bash
+hexo init my-blog
+cd my-blog
+npm install
+```
+
+> `hexo init` 會下載預設佈景主題、建立 `_config.yml` 與基本目錄；`npm install` 會把 Hexo 8 核心套件安裝到專案中。
+
+## 撰寫文章與前置資料
+
+建立新文章會自動套用 scaffold，並含有 `title`、`date`、`tags` 等 Front Matter：
+
+```bash
+hexo new "新的文章標題"
+```
+
+可於 `source/_posts/` 內編輯 Markdown 內容，並透過 `tags` 或 `categories` 整理文章。
+
+## 本機開發循環
+
+啟動本機伺服器並監看檔案變化：
+
+```bash
+hexo server
+```
+
+當檔案更新時，Hexo 會重新編譯並在瀏覽器自動刷新。若只需靜態輸出，可使用：
+
+```bash
+hexo generate
+```
+
+此指令會將產生的 HTML 放在 `public/`，可進一步用於部署或進行差異檢查。
+
+## 清理與重建
+
+遇到快取或資源錯亂時，可用 `clean` 重新整理建置狀態：
+
+```bash
+hexo clean && hexo generate
+```
+
+這會刪除 `.deploy_git`、`public/` 與快取資料，確保之後的生成結果乾淨一致。


### PR DESCRIPTION
## Summary
- refresh the Hexo installation/local development guide for Hexo 8 with updated prerequisites and CLI steps
- update the Hexo deployment/customization guide with Hexo 8 details and recommendations
- add a new tutorial covering creating posts, drafts, and asset management in Hexo 8

## Testing
- not run (documentation-only changes)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926f502dc148330986b37e6f0c3484f)