### PR TITLE
Make post cards clickable and adjust header navigation

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -18,33 +18,35 @@ const summary =
     ?.slice(0, 160) ?? '';
 ---
 <article
-  class="group relative overflow-hidden rounded-2xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-black/20 backdrop-blur transition hover:border-sky-400/40 hover:-translate-y-0.5"
+  class="group relative isolate overflow-hidden rounded-2xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-black/20 backdrop-blur transition hover:border-sky-400/40 hover:-translate-y-0.5"
 >
   <a
-    class="absolute inset-0 z-10 rounded-2xl focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+    class="absolute inset-0 rounded-2xl focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
     href={`/posts/${post.slug}/`}
     aria-label={`閱讀「${post.data.title}」`}
   ></a>
-  <div class="flex items-center justify-between text-xs text-slate-300 relative z-10">
-    <span>{formattedDate}</span>
-    {post.data.tags.length ? (
-      <div class="flex flex-wrap gap-2">
-        {post.data.tags.map((tag) => (
-          <a class="tag-pill relative z-20 no-underline" href={`/tags/${tag}/`} aria-label={`查看 #${tag} 標籤文章`}>
-            #{tag}
-          </a>
-        ))}
+  <div class="relative z-10 pointer-events-none">
+    <div class="flex items-center justify-between text-xs text-slate-300">
+      <span>{formattedDate}</span>
+      {post.data.tags.length ? (
+        <div class="flex flex-wrap gap-2">
+          {post.data.tags.map((tag) => (
+            <a class="tag-pill relative z-20 no-underline pointer-events-auto" href={`/tags/${tag}/`} aria-label={`查看 #${tag} 標籤文章`}>
+              #{tag}
+            </a>
+          ))}
+        </div>
+      ) : null}
+    </div>
+    <div>
+      <h2 class="mt-3 text-xl font-semibold text-white group-hover:text-sky-100">{post.data.title}</h2>
+      {summary && <p class="mt-3 text-sm text-slate-200 leading-relaxed">{summary}</p>}
+      <div class="mt-4 inline-flex items-center gap-2 text-sky-300 text-sm">
+        閱讀全文
+        <svg class="size-4 transition-transform group-hover:translate-x-1" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14m-6-6 6 6-6 6" />
+        </svg>
       </div>
-    ) : null}
-  </div>
-  <div class="relative z-10">
-    <h2 class="mt-3 text-xl font-semibold text-white group-hover:text-sky-100">{post.data.title}</h2>
-    {summary && <p class="mt-3 text-sm text-slate-200 leading-relaxed">{summary}</p>}
-    <div class="mt-4 inline-flex items-center gap-2 text-sky-300 text-sm">
-      閱讀全文
-      <svg class="size-4 transition-transform group-hover:translate-x-1" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14m-6-6 6 6-6 6" />
-      </svg>
     </div>
   </div>
 </article>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -34,7 +34,7 @@ const {
             A
           </div>
           <div>
-            <p class="text-lg font-semibold leading-tight">Aaron 的個人筆記</p>
+            <p class="text-lg font-semibold leading-tight">Aaron 的部落格</p>
             <p class="text-sm text-slate-300">用 Astro + Tailwind 重啟的新基地</p>
           </div>
           <svg
@@ -50,7 +50,6 @@ const {
         </a>
         <nav class="flex gap-4 text-sm text-slate-300">
           <a href="/" class="hover:text-white transition">最新文章</a>
-          <a href="https://github.com" class="hover:text-white transition" target="_blank" rel="noreferrer">GitHub</a>
         </nav>
       </header>
       <main class="max-w-5xl mx-auto px-6 pb-16">


### PR DESCRIPTION
## Summary
- make entire post card clickable while keeping tag links usable
- update site header title to "Aaron 的部落格"
- simplify navigation to only show the latest posts link

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69271cdcf1d88330b0f2fabd1aff17c0)