### PR TITLE
Update CSP and remove unused CNAME

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,0 @@
-blog.worksbyaaron.com

--- a/public/_headers
+++ b/public/_headers
@@ -4,7 +4,7 @@
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=()
-  Content-Security-Policy: default-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data;
+  Content-Security-Policy: default-src 'self'; img-src 'self' data:; script-src 'self' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data;
   Cache-Control: no-cache, must-revalidate
 
 /_astro/*


### PR DESCRIPTION
## Summary
- allow Cloudflare Insights script in the CSP header so analytics are no longer blocked
- remove the obsolete public CNAME file since Cloudflare deployment does not need it

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927d016082883308df2c14dcb6f7109)