### PR TITLE
Update permissions policy header

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -3,7 +3,7 @@
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
-  Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=()
+  Permissions-Policy: camera=(), microphone=(), geolocation=()
   Cache-Control: public, max-age=3600, must-revalidate
 
 /_astro/*


### PR DESCRIPTION
## Summary
- remove the deprecated interest-cohort directive from the permissions policy header

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bfc6039fc83308b357941a2045559)