### PR TITLE
Prevent breadcrumb wrapping and enable URL breaking in post content

### DIFF
--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -32,11 +32,11 @@ const isoDate = post.data.date ? new Date(post.data.date).toISOString() : "";
   description={post.data.description ?? post.data.title}
   image={post.data.cover?.src}>
   <nav
-    class="mb-8 flex items-center gap-2 text-sm text-slate-400"
+    class="mb-8 flex min-w-0 items-center gap-2 text-sm text-slate-400 whitespace-nowrap"
     aria-label="麵包屑">
-    <a href="/" class="hover:text-sky-300 transition">首頁</a>
+    <a href="/" class="shrink-0 hover:text-sky-300 transition">首頁</a>
     <svg
-      class="size-4"
+      class="size-4 shrink-0"
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
@@ -44,10 +44,10 @@ const isoDate = post.data.date ? new Date(post.data.date).toISOString() : "";
       <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"
       ></path>
     </svg>
-    <span class="text-slate-200 truncate">{post.data.title}</span>
+    <span class="min-w-0 text-slate-200 truncate">{post.data.title}</span>
   </nav>
 
-  <article class="prose prose-lg">
+  <article class="prose prose-lg prose-a:break-all">
     <header class="mb-8">
       <div
         class="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-slate-400 mb-3">


### PR DESCRIPTION
### Motivation
- Prevent breadcrumb labels and icons from shrinking or wrapping on narrow viewports so the breadcrumb stays readable and the post title can truncate correctly.
- Ensure long, unbroken URLs in post content do not overflow the viewport by allowing them to break.

### Description
- Updated `src/pages/posts/[slug].astro` to add layout classes to the breadcrumb: `min-w-0`, `whitespace-nowrap`, and applied `shrink-0` to the home link and chevron icon.
- Kept the post title truncation by wrapping it in a `span` with `min-w-0` and `truncate`.
- Enabled breaking of long links inside post content by adding the `prose-a:break-all` utility to the article element.

### Testing
- Started the dev server with `npm run dev` and the server came up successfully (Astro ready).
- Performed a `curl -I` request to the updated post page which returned `HTTP/1.1 200 OK` indicating the page served correctly.
- Attempted an automated Playwright screenshot to visually verify the layout, but the Playwright run failed to connect to the dev server (connection refused).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69462662433c832db2b82ce37c262a85)