### PR TITLE
Load Noto Sans TC asynchronously to reduce render-blocking CSS

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,7 +1,7 @@
 ---
 import { ClientRouter } from "astro:transitions";
 import "../styles/global.css";
-import "@fontsource-variable/noto-sans-tc";
+import fontsHref from "../styles/fonts.css?url";
 
 const {
   title = "Aaron 的部落格",
@@ -39,6 +39,14 @@ const {
     <meta property="twitter:title" content={title} />
     <meta property="twitter:description" content={description} />
     <meta property="twitter:image" content={new URL(image, Astro.url)} />
+
+    <link rel="preload" as="style" href={fontsHref} />
+    <link
+      rel="stylesheet"
+      href={fontsHref}
+      media="print"
+      onload="this.media='all'" />
+    <noscript><link rel="stylesheet" href={fontsHref} /></noscript>
 
     <ClientRouter />
   </head>

--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -1,0 +1,1 @@
+@import "@fontsource-variable/noto-sans-tc/wght.css";


### PR DESCRIPTION
### Motivation
- Reduce render-blocking CSS caused by importing the full font file directly in the main layout.  
- Improve Lighthouse performance by deferring font stylesheet application until after initial render.  
- Use a non-blocking font loading pattern (preload + media-swap) to keep first paint fast.  

### Description
- Replaced the direct `import "@fontsource-variable/noto-sans-tc"` in `src/layouts/BaseLayout.astro` with `import fontsHref from "../styles/fonts.css?url"` to obtain a URL for the font stylesheet.  
- Added a preload plus media-swap pattern in the `<head>`: ` <link rel="preload" as="style" href={fontsHref} />`, a deferred stylesheet `<link rel="stylesheet" href={fontsHref} media="print" onload="this.media='all'" />`, and a `<noscript>` fallback.  
- Created `src/styles/fonts.css` that contains `@import "@fontsource-variable/noto-sans-tc/wght.css"` so font-face rules are moved into a dedicated stylesheet.  
- Left `src/styles/global.css` import intact so global Tailwind styles continue to apply without change.  

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694629272bf0832d8a522344a6975b13)