### PR TITLE
Add slugifyTag utility and use slugs for tag pages/links

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -1,5 +1,6 @@
 ---
 import type { CollectionEntry } from "astro:content";
+import { slugifyTag } from "../utils/tags";
 
 interface Props {
   post: CollectionEntry<"posts">;
@@ -48,7 +49,7 @@ const summary =
             {post.data.tags.map((tag) => (
               <a
                 class="tag-pill relative z-20 no-underline pointer-events-auto"
-                href={`/tags/${tag}/`}
+                href={`/tags/${slugifyTag(tag)}/`}
                 aria-label={`查看 #${tag} 標籤文章`}>
                 #{tag}
               </a>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -2,23 +2,37 @@
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getCollection } from "astro:content";
+import { slugifyTag } from "../../utils/tags";
 
 export async function getStaticPaths() {
   const posts = await getCollection("posts", ({ data }) => !data.draft);
-  const tags = new Set<string>();
+  const slugs = new Set<string>();
 
   posts.forEach((post) => {
-    post.data.tags.forEach((tag) => tags.add(tag));
+    post.data.tags.forEach((tag) => slugs.add(slugifyTag(tag)));
   });
 
-  return Array.from(tags).map((tag) => ({
-    params: { tag },
+  return Array.from(slugs).map((slug) => ({
+    params: { tag: slug },
   }));
 }
 
-const { tag } = Astro.params;
-const filteredPosts = (await getCollection("posts", ({ data }) => !data.draft))
-  .filter((post) => post.data.tags.includes(tag ?? ""))
+const { tag: slug } = Astro.params;
+const posts = await getCollection("posts", ({ data }) => !data.draft);
+const slugToTag = new Map<string, string>();
+
+posts.forEach((post) => {
+  post.data.tags.forEach((tag) => {
+    const tagSlug = slugifyTag(tag);
+    if (!slugToTag.has(tagSlug)) {
+      slugToTag.set(tagSlug, tag);
+    }
+  });
+});
+
+const displayTag = slug ? slugToTag.get(slug) ?? slug : "";
+const filteredPosts = posts
+  .filter((post) => post.data.tags.some((tag) => slugifyTag(tag) === slug))
   .sort((a, b) => {
     const aDate = a.data.date ? new Date(a.data.date).getTime() : 0;
     const bDate = b.data.date ? new Date(b.data.date).getTime() : 0;
@@ -27,14 +41,14 @@ const filteredPosts = (await getCollection("posts", ({ data }) => !data.draft))
 ---
 
 <BaseLayout
-  title={`#${tag} 標籤文章 | Aaron 的部落格`}
-  description={`包含 #${tag} 標籤的文章彙整`}>
+  title={`#${displayTag} 標籤文章 | Aaron 的部落格`}
+  description={`包含 #${displayTag} 標籤的文章彙整`}>
   <section class="grid gap-6">
     <div class="flex items-center gap-3">
       <a href="/" class="text-sm text-sky-200 hover:text-sky-100"
         >← 返回文章彙整</a
       >
-      <span class="tag-pill text-sm">#{tag}</span>
+      <span class="tag-pill text-sm">#{displayTag}</span>
     </div>
     <div class="grid gap-4">
       {

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,17 +1,20 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { getCollection } from "astro:content";
+import { slugifyTag } from "../../utils/tags";
 
 const posts = await getCollection("posts", ({ data }) => !data.draft);
-const tagMap = new Map<string, number>();
+const tagMap = new Map<string, { count: number; display: string; slug: string }>();
 
 posts.forEach((post) => {
   post.data.tags.forEach((tag) => {
-    tagMap.set(tag, (tagMap.get(tag) ?? 0) + 1);
+    const slug = slugifyTag(tag);
+    const current = tagMap.get(slug) ?? { count: 0, display: tag, slug };
+    tagMap.set(slug, { ...current, count: current.count + 1 });
   });
 });
 
-const tags = Array.from(tagMap.entries()).sort((a, b) => b[1] - a[1]);
+const tags = Array.from(tagMap.values()).sort((a, b) => b.count - a.count);
 ---
 
 <BaseLayout title="所有標籤 | Aaron 的部落格" description="瀏覽部落格使用中的所有標籤與文章數量。">
@@ -28,15 +31,15 @@ const tags = Array.from(tagMap.entries()).sort((a, b) => b[1] - a[1]);
         tags.length === 0 ? (
           <p class="text-slate-300">目前還沒有任何標籤。</p>
         ) : (
-          tags.map(([tag, count]) => (
+          tags.map((tag) => (
             <a
-              href={`/tags/${tag}/`}
+              href={`/tags/${tag.slug}/`}
               class="group relative isolate overflow-hidden rounded-xl border border-white/10 bg-white/5 px-4 py-3 transition hover:border-sky-400/40 hover:-translate-y-0.5 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-sky-400"
-              aria-label={`查看 #${tag} 標籤的 ${count} 篇文章`}>
+              aria-label={`查看 #${tag.display} 標籤的 ${tag.count} 篇文章`}>
               <div class="flex items-center justify-between gap-3">
-                <span class="tag-pill text-sm">#{tag}</span>
+                <span class="tag-pill text-sm">#{tag.display}</span>
                 <span class="text-xs text-slate-200 group-hover:text-sky-100">
-                  {count} 篇
+                  {tag.count} 篇
                 </span>
               </div>
             </a>

--- a/src/utils/tags.ts
+++ b/src/utils/tags.ts
@@ -1,9 +1,15 @@
 export function slugifyTag(tag: string): string {
-  return tag
+  const normalized = tag
     .trim()
     .toLowerCase()
     .replace(/\s+/g, "-")
     .replace(/[^a-z0-9-]/g, "")
     .replace(/-+/g, "-")
     .replace(/^-|-$/g, "");
+
+  if (normalized) {
+    return normalized;
+  }
+
+  return encodeURIComponent(tag.trim().toLowerCase());
 }

--- a/src/utils/tags.ts
+++ b/src/utils/tags.ts
@@ -1,0 +1,9 @@
+export function slugifyTag(tag: string): string {
+  return tag
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}


### PR DESCRIPTION
### Motivation
- Create URL-friendly, consistent tag routes by generating slugs for tags using a shared utility `slugifyTag`.
- Preserve human-readable tag display names while using slugs in URLs to avoid unsafe characters and spacing issues.
- Ensure tag index and tag detail pages, as well as post tag links, all reference the same slug format for predictable routing.

### Description
- Added `src/utils/tags.ts` implementing `slugifyTag(tag: string): string` to normalize tags into URL-safe slugs.
- Updated `src/pages/tags/index.astro` to aggregate tags by slug while preserving `display` and `count`, and link to `/tags/${slug}/`.
- Updated `src/pages/tags/[tag].astro` to generate `getStaticPaths` from slugs and resolve a `slug -> original tag` mapping to display the original tag name while filtering posts by slug.
- Updated `src/components/PostCard.astro` to use `slugifyTag` when generating tag links so post cards link to `/tags/${slug}/` but still show the original tag text.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69468b3e4930832d9d52596e4d8765a8)