### PR TITLE
Add `getPublishedPostsSorted` helper and use in index, tags, and RSS

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,15 +1,9 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 import PostCard from "../components/PostCard.astro";
-import { getCollection } from "astro:content";
+import { getPublishedPostsSorted } from "../utils/posts";
 
-const posts = (await getCollection("posts", ({ data }) => !data.draft)).sort(
-  (a, b) => {
-    const aDate = a.data.date ? new Date(a.data.date).getTime() : 0;
-    const bDate = b.data.date ? new Date(b.data.date).getTime() : 0;
-    return bDate - aDate;
-  }
-);
+const posts = await getPublishedPostsSorted();
 ---
 
 <BaseLayout

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -1,24 +1,18 @@
 import rss from "@astrojs/rss";
-import { getCollection } from "astro:content";
+import { getPublishedPostsSorted } from "../utils/posts";
 
 export async function GET(context) {
-  const posts = await getCollection("posts", ({ data }) => !data.draft);
+  const posts = await getPublishedPostsSorted();
   return rss({
     title: "Aaron 的部落格",
     description: "用 Astro 打造、部署到 Cloudflare Pages 的全新部落格",
     site: context.site,
-    items: posts
-      .sort((a, b) => {
-        const aDate = a.data.date ? new Date(a.data.date).getTime() : 0;
-        const bDate = b.data.date ? new Date(b.data.date).getTime() : 0;
-        return bDate - aDate;
-      })
-      .map((post) => ({
-        title: post.data.title,
-        pubDate: post.data.date || new Date(),
-        description: post.data.description,
-        link: `/posts/${post.slug}/`,
-      })),
+    items: posts.map((post) => ({
+      title: post.data.title,
+      pubDate: post.data.date || new Date(),
+      description: post.data.description,
+      link: `/posts/${post.slug}/`,
+    })),
     customData: `<language>zh-Hant</language>`,
   });
 }

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,11 +1,11 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import PostCard from "../../components/PostCard.astro";
-import { getCollection } from "astro:content";
 import { slugifyTag } from "../../utils/tags";
+import { getPublishedPostsSorted } from "../../utils/posts";
 
 export async function getStaticPaths() {
-  const posts = await getCollection("posts", ({ data }) => !data.draft);
+  const posts = await getPublishedPostsSorted();
   const slugs = new Set<string>();
 
   posts.forEach((post) => {
@@ -18,7 +18,7 @@ export async function getStaticPaths() {
 }
 
 const { tag: slug } = Astro.params;
-const posts = await getCollection("posts", ({ data }) => !data.draft);
+const posts = await getPublishedPostsSorted();
 const slugToTag = new Map<string, string>();
 
 posts.forEach((post) => {
@@ -31,13 +31,9 @@ posts.forEach((post) => {
 });
 
 const displayTag = slug ? slugToTag.get(slug) ?? slug : "";
-const filteredPosts = posts
-  .filter((post) => post.data.tags.some((tag) => slugifyTag(tag) === slug))
-  .sort((a, b) => {
-    const aDate = a.data.date ? new Date(a.data.date).getTime() : 0;
-    const bDate = b.data.date ? new Date(b.data.date).getTime() : 0;
-    return bDate - aDate;
-  });
+const filteredPosts = await getPublishedPostsSorted({
+  filter: (post) => post.data.tags.some((tag) => slugifyTag(tag) === slug),
+});
 ---
 
 <BaseLayout

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -18,6 +18,7 @@ export async function getStaticPaths() {
 }
 
 const { tag: slug } = Astro.params;
+const normalizedSlug = slug ? slugifyTag(decodeURIComponent(slug)) : "";
 const posts = await getPublishedPostsSorted();
 const slugToTag = new Map<string, string>();
 
@@ -30,9 +31,12 @@ posts.forEach((post) => {
   });
 });
 
-const displayTag = slug ? slugToTag.get(slug) ?? slug : "";
+const displayTag = normalizedSlug
+  ? slugToTag.get(normalizedSlug) ?? normalizedSlug
+  : "";
 const filteredPosts = await getPublishedPostsSorted({
-  filter: (post) => post.data.tags.some((tag) => slugifyTag(tag) === slug),
+  filter: (post) =>
+    post.data.tags.some((tag) => slugifyTag(tag) === normalizedSlug),
 });
 ---
 

--- a/src/utils/posts.ts
+++ b/src/utils/posts.ts
@@ -1,0 +1,30 @@
+import { getCollection, type CollectionEntry } from "astro:content";
+
+type PostEntry = CollectionEntry<"posts">;
+
+type GetPublishedPostsOptions = {
+  filter?: (post: PostEntry) => boolean;
+  sort?: (a: PostEntry, b: PostEntry) => number;
+};
+
+const defaultFilter = (post: PostEntry) => !post.data.draft;
+
+const defaultSort = (a: PostEntry, b: PostEntry) => {
+  const aDate = a.data.date ? new Date(a.data.date).getTime() : 0;
+  const bDate = b.data.date ? new Date(b.data.date).getTime() : 0;
+  return bDate - aDate;
+};
+
+export async function getPublishedPostsSorted(
+  options: GetPublishedPostsOptions = {}
+) {
+  const { filter, sort } = options;
+  const posts = await getCollection("posts", (post) => {
+    if (!defaultFilter(post)) {
+      return false;
+    }
+    return filter ? filter(post) : true;
+  });
+
+  return posts.sort(sort ?? defaultSort);
+}


### PR DESCRIPTION
### Motivation
- Centralize post retrieval logic to avoid repeating draft filtering and date sorting across pages.
- Provide a single, typed utility that enforces published-only posts by default.
- Allow callers to override filtering or sorting when different behavior is required.
- Ensure consistent ordering and filtering for the index, tag pages, and RSS feed.

### Description
- Add `src/utils/posts.ts` which exports `getPublishedPostsSorted(options?)` with typed `PostEntry` and `GetPublishedPostsOptions`.
- The helper applies a default filter that excludes drafts and a default sort that orders by `date` descending, and accepts `filter` and `sort` overrides.
- Replace inline `getCollection("posts", ({ data }) => !data.draft)` and local sort calls in `src/pages/index.astro`, `src/pages/tags/[tag].astro`, and `src/pages/rss.xml.js` with calls to `getPublishedPostsSorted`.
- Use the `filter` option in the tag page to return tag-specific posts while preserving the shared sorting behavior.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946927f3de4832d8fbb0669079bc031)