### PR TITLE
Fix tag filtering for non-ASCII slugs

### DIFF
--- a/src/utils/tags.ts
+++ b/src/utils/tags.ts
@@ -1,15 +1,11 @@
 export function slugifyTag(tag: string): string {
-  const normalized = tag
-    .trim()
+  const trimmed = tag.trim();
+  const normalized = trimmed
     .toLowerCase()
     .replace(/\s+/g, "-")
     .replace(/[^a-z0-9-]/g, "")
     .replace(/-+/g, "-")
     .replace(/^-|-$/g, "");
 
-  if (normalized) {
-    return normalized;
-  }
-
-  return encodeURIComponent(tag.trim().toLowerCase());
+  return normalized || trimmed;
 }


### PR DESCRIPTION
### Motivation
- Selecting tags written in non-ASCII (e.g., Chinese) showed all posts instead of only matching posts.  
- The root cause was `slugifyTag` returning a percent-encoded fallback for tags that normalized to an empty ASCII-only string, causing slug comparisons to mismatch.  
- Tag filtering must work regardless of the language the tag is written in so slugs used across pages remain consistent.

### Description
- Update `src/utils/tags.ts` in the `slugifyTag` helper to `trim` first and compute `normalized` from the trimmed value.  
- Return `normalized || trimmed` instead of percent-encoding the trimmed tag, preserving non-ASCII tags while still normalizing ASCII tags.  
- This change removes the previous percent-encoding fallback so slug comparisons between tag index, tag pages, and post links remain consistent.

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69469e21cdd4832daf9fad9180fd93e4)