### PR TITLE
Add RSS alternate link to base layout

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -25,6 +25,11 @@ const {
     <meta name="theme-color" content="#0f172a" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="canonical" href={canonicalURL} />
+    <link
+      rel="alternate"
+      type="application/rss+xml"
+      title="Aaron 的部落格"
+      href="/rss.xml" />
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />


### PR DESCRIPTION
### Motivation
- Expose the site's RSS feed via a discovery link in the document head so feed readers and crawlers can find `/rss.xml` automatically.
- Improve discoverability for consumers and aggregators by advertising the feed in the base layout shared across pages.
- Keep the change minimal and centralized by adding the link in the global layout `src/layouts/BaseLayout.astro`.
- Leave room for future enhancements where feed `title` and `href` could be controlled via props for multi-language or multiple feeds.

### Description
- Added a `<link rel="alternate" type="application/rss+xml" title="Aaron 的部落格" href="/rss.xml" />` element inside the `<head>` of `src/layouts/BaseLayout.astro`.
- The insertion is placed next to the existing canonical and favicon links so it is available site-wide.
- No other markup or logic was changed and no new files were added.
- The change is a single-file update to the base layout for global effect.

### Testing
- No automated tests were run for this change.
- There were no unit tests or CI steps executed as part of this edit.
- The file was linted implicitly by the editor/commit environment (no reported errors).
- A commit was created containing the single-file update which applied cleanly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946a058be84832da3e234efe89eff24)