### PR TITLE
Require post dates across content and UI

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -7,14 +7,12 @@ interface Props {
 }
 
 const { post } = Astro.props;
-const formattedDate = post.data.date
-  ? new Date(post.data.date).toLocaleDateString("zh-TW", {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    })
-  : "未設定日期";
-const isoDate = post.data.date ? new Date(post.data.date).toISOString() : "";
+const formattedDate = new Date(post.data.date).toLocaleDateString("zh-TW", {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+});
+const isoDate = new Date(post.data.date).toISOString();
 const summary =
   post.data.description ??
   post.body
@@ -34,15 +32,9 @@ const summary =
   <div class="relative z-10 pointer-events-none">
     <div
       class="flex flex-col gap-2 text-xs text-slate-300 sm:flex-row sm:items-center sm:justify-between">
-      {
-        post.data.date ? (
-          <time datetime={isoDate} class="shrink-0">
-            {formattedDate}
-          </time>
-        ) : (
-          <span class="shrink-0">{formattedDate}</span>
-        )
-      }
+      <time datetime={isoDate} class="shrink-0">
+        {formattedDate}
+      </time>
       {
         post.data.tags.length ? (
           <div class="flex flex-wrap gap-2">

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -6,7 +6,7 @@ const posts = defineCollection({
     z.object({
       title: z.string(),
       description: z.string().optional(),
-      date: z.coerce.date().optional(),
+      date: z.coerce.date(),
       tags: z.array(z.string()).default([]),
       cover: image().optional(),
       draft: z.boolean().default(false),

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -17,14 +17,12 @@ const { Content } = await post.render();
 const wordCount = post.body.split(/\s+/).length;
 const readingTime = Math.ceil(wordCount / 200);
 
-const formattedDate = post.data.date
-  ? new Date(post.data.date).toLocaleDateString("zh-TW", {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    })
-  : "未設定日期";
-const isoDate = post.data.date ? new Date(post.data.date).toISOString() : "";
+const formattedDate = new Date(post.data.date).toLocaleDateString("zh-TW", {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+});
+const isoDate = new Date(post.data.date).toISOString();
 ---
 
 <BaseLayout
@@ -51,13 +49,7 @@ const isoDate = post.data.date ? new Date(post.data.date).toISOString() : "";
     <header class="mb-8">
       <div
         class="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-slate-400 mb-3">
-        {
-          post.data.date ? (
-            <time datetime={isoDate}>{formattedDate}</time>
-          ) : (
-            <span>{formattedDate}</span>
-          )
-        }
+        <time datetime={isoDate}>{formattedDate}</time>
         <span class="flex items-center gap-1">
           <svg
             class="size-4"

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -9,7 +9,7 @@ export async function GET(context) {
     site: context.site,
     items: posts.map((post) => ({
       title: post.data.title,
-      pubDate: post.data.date || new Date(),
+      pubDate: post.data.date,
       description: post.data.description,
       link: `/posts/${post.slug}/`,
     })),


### PR DESCRIPTION
### Motivation

- 強制在內容模型中填寫 `date`，避免在 UI 或 RSS 使用預設時間導致資料不一致。 
- 讓 RSS feed 使用文章的真實發布日期而非 fallback 值。 
- 簡化前端顯示邏輯，移除顯示「未設定日期」的分支以符合資料模型。 
- 確保前端、RSS 與內容檔案行為一致。 

### Description

- 在 `src/content/config.ts` 將 `date` 從 `z.coerce.date().optional()` 改為必填 `z.coerce.date()`. 
- 在 `src/pages/rss.xml.js` 移除 `|| new Date()`，直接使用 `post.data.date` 作為 `pubDate`. 
- 在 `src/components/PostCard.astro` 與 `src/pages/posts/[slug].astro` 移除「未設定日期」分支，並改為直接用 `new Date(post.data.date)` 產生 `formattedDate` 與 `isoDate`. 
- 現有的 Markdown 文章已包含 `date` frontmatter，因此內容檔案未做變更。 

### Testing

- 未執行任何自動化測試（未請求）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946a1931fbc832db894eaaedaa3e840)