### PR TITLE
Extract summary utility and strip Markdown links for PostCard

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -1,5 +1,6 @@
 ---
 import type { CollectionEntry } from "astro:content";
+import { toPlainTextExcerpt } from "../utils/summary";
 import { slugifyTag } from "../utils/tags";
 
 interface Props {
@@ -13,14 +14,11 @@ const formattedDate = new Date(post.data.date).toLocaleDateString("zh-TW", {
   day: "numeric",
 });
 const isoDate = new Date(post.data.date).toISOString();
-const summary =
+const summarySource =
   post.data.description ??
-  post.body
-    .split("\n")
-    .find((line) => line.trim())
-    ?.replace(/[#*>`]/g, "")
-    ?.slice(0, 160) ??
+  post.body.split("\n").find((line) => line.trim()) ??
   "";
+const summary = toPlainTextExcerpt(summarySource);
 ---
 
 <article

--- a/src/utils/summary.ts
+++ b/src/utils/summary.ts
@@ -1,0 +1,14 @@
+export const stripMarkdownLinks = (text: string): string =>
+  text.replace(/\[(.*?)\]\((.*?)\)/g, "$1");
+
+export const toPlainTextExcerpt = (
+  text: string,
+  maxLength = 160,
+): string => {
+  if (!text) return "";
+
+  return stripMarkdownLinks(text)
+    .replace(/[#*>`]/g, "")
+    .trim()
+    .slice(0, maxLength);
+};


### PR DESCRIPTION
### Motivation
- Ensure post summaries are plain text by removing Markdown links like `[text](url)` before truncation.
- Centralize summary processing so other components can reuse the same logic and avoid duplication.
- Preserve existing symbol cleanup (e.g., `#`, `*`, `>`, `` ` ``) and truncation behavior while improving link handling.

### Description
- Add `src/utils/summary.ts` with `stripMarkdownLinks` and `toPlainTextExcerpt` functions to transform markdown into plain excerpts.
- Update `src/components/PostCard.astro` to compute `summarySource` and call `toPlainTextExcerpt(summarySource)` for the displayed summary.
- Use the regex `/\[(.*?)\]\((.*?)\)/g` to strip Markdown links and reuse existing symbol cleanup and slicing logic.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946c30afc28832d8743052f06411952)