### PR TITLE
Refine summary plain-text extraction to remove list markers and collapse whitespace

### DIFF
--- a/src/utils/summary.ts
+++ b/src/utils/summary.ts
@@ -8,7 +8,8 @@ export const toPlainTextExcerpt = (
   if (!text) return "";
 
   return stripMarkdownLinks(text)
-    .replace(/[#*>`]/g, "")
+    .replace(/[#>*-]/g, "")
+    .replace(/\s+/g, " ")
     .trim()
     .slice(0, maxLength);
 };


### PR DESCRIPTION
### Motivation
- Ensure summaries are derived from plain text before truncation to a fixed length like `160` characters.
- Remove Markdown artifacts such as links and structural markers so excerpts are human-readable.
- Normalize whitespace so multi-line or multi-space input becomes a single-line excerpt suitable for list pages.

### Description
- Updated `toPlainTextExcerpt` in `src/utils/summary.ts` to collapse consecutive whitespace with `.replace(/\s+/g, " ")` before trimming and slicing.
- Adjusted the marker-stripping regex to remove heading/quote/list symbols including the dash via `.replace(/[#>*-]/g, "")`.
- Continued to use `stripMarkdownLinks` to strip Markdown link URLs before other plain-text normalization.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946cb7a6194832d92ac992099f85a90)