### PR TITLE
Use slugified tag links on post page

### DIFF
--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { getCollection } from "astro:content";
+import { slugifyTag } from "../../utils/tags";
 
 export async function getStaticPaths() {
   const posts = await getCollection("posts", ({ data }) => !data.draft);
@@ -74,7 +75,7 @@ const isoDate = new Date(post.data.date).toISOString();
             {post.data.tags.map((tag) => (
               <a
                 class="tag-pill no-underline"
-                href={`/tags/${tag}/`}
+                href={`/tags/${slugifyTag(tag)}/`}
                 aria-label={`查看 #${tag} 標籤文章`}>
                 #{tag}
               </a>


### PR DESCRIPTION
### Motivation
- Ensure tag URLs are URL-friendly and consistent by slugifying tag names.
- Prevent issues with tags containing spaces or special characters from breaking tag routes.

### Description
- Import `slugifyTag` from `../../utils/tags` into `src/pages/posts/[slug].astro`.
- Replace tag link `href` from `/tags/${tag}/` to `/tags/${slugifyTag(tag)}/` while keeping the displayed text as `#{tag}`.
- Change only affects the tag link generation in the post page template.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946cee44b24832d8ed8bd507c162022)