### PR TITLE
Remove nested prose wrapper in post page

### DIFF
--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -84,8 +84,6 @@ const isoDate = new Date(post.data.date).toISOString();
         ) : null
       }
     </header>
-    <div class="prose">
-      <Content />
-    </div>
+    <Content />
   </article>
 </BaseLayout>


### PR DESCRIPTION
### Motivation
- Simplify the post page markup by removing an unnecessary nested `prose` wrapper. 
- Let the existing `article` element's `class="prose prose-lg prose-a:break-all"` provide typographic styles directly to the rendered content. 
- Reduce DOM depth and avoid potential duplicated styling from nested `.prose` classes.

### Description
- Removed the inner `<div class="prose">` wrapper and rendered `<Content />` directly inside the `article`. 
- Modified `src/pages/posts/[slug].astro` to reflect this change. 
- Kept the outer `article` element and its classes intact so visual styles remain the same.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946d0ba9f04832d8a179ffc9511e6dc)