### PR TITLE
Inline markdown link stripping into `toPlainTextExcerpt`

### DIFF
--- a/src/utils/summary.ts
+++ b/src/utils/summary.ts
@@ -1,11 +1,11 @@
-export const stripMarkdownLinks = (text: string): string =>
-  text.replace(/\[(.*?)\]\((.*?)\)/g, "$1");
-
 export const toPlainTextExcerpt = (
   text: string,
   maxLength = 160,
 ): string => {
   if (!text) return "";
+
+  const stripMarkdownLinks = (value: string): string =>
+    value.replace(/\[(.*?)\]\((.*?)\)/g, "$1");
 
   return stripMarkdownLinks(text)
     .replace(/[#>*-]/g, "")


### PR DESCRIPTION
### Motivation

- The helper `stripMarkdownLinks` was exported but only used by `toPlainTextExcerpt`, so its scope can be reduced.  
- Encapsulating the link-stripping logic keeps the public API minimal and reduces surface area for consumers.  
- Keeping behavior identical while limiting exports improves module cohesion.  

### Description

- Removed the top-level exported `stripMarkdownLinks` and added a private `stripMarkdownLinks` function inside `toPlainTextExcerpt`.  
- Preserved the existing regex and transformation chain, so `toPlainTextExcerpt` still strips markdown links, removes `[#>*-]`, normalizes whitespace, trims, and slices to `maxLength`.  
- No changes were made to the exported API surface aside from no longer exporting `stripMarkdownLinks`.  

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946d4920ae8832d8f79affbe3e8d522)