### PR TITLE
Harden tag slug fallback and add encoded/default slugs

### DIFF
--- a/src/utils/tags.ts
+++ b/src/utils/tags.ts
@@ -7,5 +7,23 @@ export function slugifyTag(tag: string): string {
     .replace(/-+/g, "-")
     .replace(/^-|-$/g, "");
 
-  return normalized || trimmed;
+  if (normalized) {
+    return normalized;
+  }
+
+  if (trimmed) {
+    return encodeURIComponent(trimmed);
+  }
+
+  return `tag-${hashTag(tag)}`;
+}
+
+function hashTag(tag: string): number {
+  let hash = 5381;
+
+  for (let i = 0; i < tag.length; i += 1) {
+    hash = (hash * 33) ^ tag.charCodeAt(i);
+  }
+
+  return hash >>> 0;
 }


### PR DESCRIPTION
### Motivation
- Prevent returning raw `trimmed` values as tag slugs to avoid producing slugs containing spaces or special characters.
- Ensure tags that normalize to an empty string still produce a stable, URL-safe slug for `/tags/<slug>/` routes.
- Provide a deterministic fallback when the input tag is empty so downstream route generation and matching remain well-defined.

### Description
- Replace the `normalized || trimmed` fallback with explicit branches that return `normalized`, then `encodeURIComponent(trimmed)`, and finally a hashed default.
- Add a `hashTag` helper that computes a deterministic numeric hash and use it to build a `tag-<hash>` fallback slug for empty inputs.
- Keep the existing normalization steps (`toLowerCase`, whitespace-to-dash, strip non-alphanumerics, collapse dashes, trim edge dashes) unchanged.
- Surface only URL-safe values from `slugifyTag` so callers that generate `/tags/<slug>/` receive encoded or alphanumeric slugs.

### Testing
- No automated tests were run for this change.
- No CI or type-checking was invoked as part of this update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946d9d3333c832db79a13a78375c2b9)