### PR TITLE
Add Traditional Chinese intent comments for summaries, tags, and reading time

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -14,6 +14,7 @@ const formattedDate = new Date(post.data.date).toLocaleDateString("zh-TW", {
   day: "numeric",
 });
 const isoDate = new Date(post.data.date).toISOString();
+// 為了確保摘要穩定且有語意，優先用 description，其次取內文首個非空行再轉成純文字摘要。
 const summarySource =
   post.data.description ??
   post.body.split("\n").find((line) => line.trim()) ??

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -14,7 +14,7 @@ export async function getStaticPaths() {
 const { post } = Astro.props;
 const { Content } = await post.render();
 
-// Calculate simple reading time if not provided by remark plugin
+// 用 200 WPM 估算閱讀時間，提供一致的閱讀門檻提示即使沒有外掛資料也可用。
 const wordCount = post.body.split(/\s+/).length;
 const readingTime = Math.ceil(wordCount / 200);
 

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -31,6 +31,7 @@ posts.forEach((post) => {
   });
 });
 
+// 用現有文章還原 slug 對應的原始標籤，確保顯示維持作者寫法而非機械化 slug。
 const displayTag = normalizedSlug
   ? slugToTag.get(normalizedSlug) ?? normalizedSlug
   : "";

--- a/src/utils/summary.ts
+++ b/src/utils/summary.ts
@@ -4,6 +4,7 @@ export const toPlainTextExcerpt = (
 ): string => {
   if (!text) return "";
 
+  // 先去除連結語法再壓成純文字與固定長度，避免摘要帶有 Markdown 雜訊影響可讀性。
   const stripMarkdownLinks = (value: string): string =>
     value.replace(/\[(.*?)\]\((.*?)\)/g, "$1");
 

--- a/src/utils/tags.ts
+++ b/src/utils/tags.ts
@@ -1,5 +1,6 @@
 export function slugifyTag(tag: string): string {
   const trimmed = tag.trim();
+  // 使用小寫英數與連字號的保守規則，確保 URL 乾淨且跨語系不易出錯。
   const normalized = trimmed
     .toLowerCase()
     .replace(/\s+/g, "-")


### PR DESCRIPTION
### Motivation
- Clarify the intent behind summary selection and preprocessing so maintainers understand why `description` is preferred and how excerpts are derived.
- Explain the `slug` → display tag restoration to preserve the author’s original tag casing and punctuation when showing UI labels.
- Document the design decision for the summary processing steps to avoid Markdown artifacts in excerpts.
- Make the reading-time heuristic explicit by noting the `200 WPM` assumption used when no plugin data is available.

### Description
- Add a Traditional Chinese intent comment in `src/components/PostCard.astro` describing the summary source priority (`description` → first non-empty body line → excerpt).
- Add a Traditional Chinese intent comment in `src/pages/tags/[tag].astro` explaining the `slug` → original tag lookup to keep display text faithful to author input.
- Add a Traditional Chinese intent comment in `src/utils/summary.ts` describing the link-stripping and plain-text truncation step to remove Markdown noise from excerpts.
- Add a Traditional Chinese intent comment in `src/utils/tags.ts` that explains the conservative lowercase alphanumeric-and-hyphen slugification rule, and in `src/pages/posts/[slug].astro` noting the `200 WPM` reading-time estimation.

### Testing
- No automated tests were run for these comment-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946dc1efccc832da36ff4d5934f7fa5)