### PR TITLE
Remove unused astro-font dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,9 @@
       "dependencies": {
         "@astrojs/rss": "^4.0.14",
         "@astrojs/sitemap": "^3.6.0",
-        "@fontsource-variable/noto-sans-tc": "^5.2.5",
+        "@fontsource-variable/noto-sans-tc": "^5.2.9",
         "@tailwindcss/vite": "^4.1.18",
         "astro": "^5.16.6",
-        "astro-font": "^1.1.0",
         "tailwindcss": "^4.1.18"
       },
       "devDependencies": {
@@ -2438,12 +2437,6 @@
       "optionalDependencies": {
         "sharp": "^0.34.0"
       }
-    },
-    "node_modules/astro-font": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/astro-font/-/astro-font-1.1.0.tgz",
-      "integrity": "sha512-hj1A0MkaJTeaArBpf1m9s4Nxu1Bn9h0QiEPeR9Dfjle25pT4CH4higzuadWzCRSvhGO2SzbM11YwZEF+cmLDxg==",
-      "license": "MIT"
     },
     "node_modules/axobject-query": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -13,10 +13,9 @@
   "dependencies": {
     "@astrojs/rss": "^4.0.14",
     "@astrojs/sitemap": "^3.6.0",
-    "@fontsource-variable/noto-sans-tc": "^5.2.5",
+    "@fontsource-variable/noto-sans-tc": "^5.2.9",
     "@tailwindcss/vite": "^4.1.18",
     "astro": "^5.16.6",
-    "astro-font": "^1.1.0",
     "tailwindcss": "^4.1.18"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- remove unused astro-font package to avoid duplicate font tooling

## Testing
- npm run check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950cbea5328832dafe3113035256c8b)